### PR TITLE
Feature/7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Mac ###
 .DS_Store
+
+### Secret ###
+aws-s3.yml

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// AWS S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dasibom/practice/config/AmazonS3Config.java
+++ b/src/main/java/com/dasibom/practice/config/AmazonS3Config.java
@@ -1,0 +1,33 @@
+package com.dasibom.practice.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class AmazonS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/com/dasibom/practice/controller/DiaryController.java
+++ b/src/main/java/com/dasibom/practice/controller/DiaryController.java
@@ -1,0 +1,39 @@
+package com.dasibom.practice.controller;
+
+import com.dasibom.practice.domain.Diary;
+import com.dasibom.practice.domain.Response;
+import com.dasibom.practice.domain.dto.DiarySaveReqDto;
+import com.dasibom.practice.service.DiaryService;
+import com.dasibom.practice.service.S3Service;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/diary")
+@Slf4j
+public class DiaryController {
+
+    private final DiaryService diaryService;
+    private final S3Service s3Service;
+
+    @PostMapping(value = "/save", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public Response save(@RequestPart @Valid DiarySaveReqDto requestDto,
+            @RequestPart(required = false) List<MultipartFile> multipartFile) {
+
+        Diary diary = diaryService.save(requestDto);
+        if (multipartFile != null) {
+            s3Service.uploadImage(multipartFile, "Diary", diary);
+        }
+
+        return new Response("OK", "일기 등록에 성공했습니다");
+    }
+}

--- a/src/main/java/com/dasibom/practice/domain/Diary.java
+++ b/src/main/java/com/dasibom/practice/domain/Diary.java
@@ -2,7 +2,6 @@ package com.dasibom.practice.domain;
 
 import java.time.LocalDate;
 import java.util.List;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,9 +11,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
@@ -38,11 +34,9 @@ public class Diary {
     private String title;
     private String content;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @CreationTimestamp
     private LocalDate createdAt;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @CreationTimestamp
     private LocalDate updatedAt;
 }

--- a/src/main/java/com/dasibom/practice/domain/Diary.java
+++ b/src/main/java/com/dasibom/practice/domain/Diary.java
@@ -12,16 +12,18 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
+@Setter
 public class Diary {
     @Id
     @GeneratedValue
     @Column(name = "diaryId")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "petId")
     private Pet pet;
 
@@ -33,7 +35,7 @@ public class Diary {
     private List<DiaryImage> images = new ArrayList<>();
 
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
-    private List<DiaryStamp> stamps;
+    private List<DiaryStamp> stamps = new ArrayList<>();
 
     private String title;
     private String content;
@@ -43,4 +45,21 @@ public class Diary {
 
     @CreationTimestamp
     private LocalDate updatedAt;
+
+    public void addDiaryStamp(DiaryStamp diaryStamp) {
+        stamps.add(diaryStamp);
+        diaryStamp.setDiary(this);
+    }
+
+    public static Diary createDiary(User user,Pet pet, String title, String content, List<DiaryStamp> stamps) {
+        Diary diary = new Diary();
+        diary.setAuthor(user);
+        diary.setPet(pet);
+        for (DiaryStamp stamp : stamps) {
+            diary.addDiaryStamp(stamp);
+        }
+        diary.setTitle(title);
+        diary.setContent(content);
+        return diary;
+    }
 }

--- a/src/main/java/com/dasibom/practice/domain/Diary.java
+++ b/src/main/java/com/dasibom/practice/domain/Diary.java
@@ -8,6 +8,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -19,7 +20,7 @@ import org.hibernate.annotations.CreationTimestamp;
 @Setter
 public class Diary {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "diaryId")
     private Long id;
 

--- a/src/main/java/com/dasibom/practice/domain/Diary.java
+++ b/src/main/java/com/dasibom/practice/domain/Diary.java
@@ -1,6 +1,7 @@
 package com.dasibom.practice.domain;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -27,6 +28,9 @@ public class Diary {
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "authorId")
     private User author;
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
+    private List<DiaryImage> images = new ArrayList<>();
 
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
     private List<DiaryStamp> stamps;

--- a/src/main/java/com/dasibom/practice/domain/DiaryImage.java
+++ b/src/main/java/com/dasibom/practice/domain/DiaryImage.java
@@ -8,8 +8,10 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.Setter;
 
 @Entity
+@Setter
 public class DiaryImage {
 
     @Id

--- a/src/main/java/com/dasibom/practice/domain/DiaryImage.java
+++ b/src/main/java/com/dasibom/practice/domain/DiaryImage.java
@@ -1,0 +1,26 @@
+package com.dasibom.practice.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class DiaryImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diaryImageId")
+    private Long id;
+
+    private String imgUrl;
+    private String fileName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diaryId")
+    private Diary diary;
+}

--- a/src/main/java/com/dasibom/practice/domain/DiaryStamp.java
+++ b/src/main/java/com/dasibom/practice/domain/DiaryStamp.java
@@ -5,6 +5,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -14,7 +15,7 @@ import lombok.Setter;
 @Setter
 public class DiaryStamp {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "diaryStampId")
     private Long id;
 

--- a/src/main/java/com/dasibom/practice/domain/DiaryStamp.java
+++ b/src/main/java/com/dasibom/practice/domain/DiaryStamp.java
@@ -8,8 +8,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.Setter;
 
 @Entity
+@Setter
 public class DiaryStamp {
     @Id
     @GeneratedValue
@@ -23,4 +25,11 @@ public class DiaryStamp {
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "stampId")
     private Stamp stamp;
+
+    public static DiaryStamp createDiaryStamp(Stamp stamp) {
+        DiaryStamp diaryStamp = new DiaryStamp();
+        diaryStamp.setStamp(stamp);
+        return diaryStamp;
+    }
+
 }

--- a/src/main/java/com/dasibom/practice/domain/Pet.java
+++ b/src/main/java/com/dasibom/practice/domain/Pet.java
@@ -9,6 +9,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -19,7 +20,7 @@ import lombok.Getter;
 @Getter
 public class Pet {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "petId")
     private Long id;
 

--- a/src/main/java/com/dasibom/practice/domain/Pet.java
+++ b/src/main/java/com/dasibom/practice/domain/Pet.java
@@ -13,8 +13,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Pet {
     @Id
     @GeneratedValue

--- a/src/main/java/com/dasibom/practice/domain/Response.java
+++ b/src/main/java/com/dasibom/practice/domain/Response.java
@@ -1,0 +1,14 @@
+package com.dasibom.practice.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class Response {
+
+    private String response;
+    private String message;
+}

--- a/src/main/java/com/dasibom/practice/domain/Stamp.java
+++ b/src/main/java/com/dasibom/practice/domain/Stamp.java
@@ -9,8 +9,10 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Stamp {
     @Id
     @GeneratedValue

--- a/src/main/java/com/dasibom/practice/domain/Stamp.java
+++ b/src/main/java/com/dasibom/practice/domain/Stamp.java
@@ -7,6 +7,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import lombok.Getter;
 @Getter
 public class Stamp {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "stampId")
     private Long id;
 

--- a/src/main/java/com/dasibom/practice/domain/Stamp.java
+++ b/src/main/java/com/dasibom/practice/domain/Stamp.java
@@ -6,6 +6,8 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -23,5 +25,6 @@ public class Stamp {
     @OneToMany(mappedBy = "stamp", cascade = CascadeType.ALL)
     private List<DiaryStamp> diaries = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
     private StampType stampType;
 }

--- a/src/main/java/com/dasibom/practice/domain/User.java
+++ b/src/main/java/com/dasibom/practice/domain/User.java
@@ -1,5 +1,6 @@
 package com.dasibom.practice.domain;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.CascadeType;
@@ -17,10 +18,10 @@ public class User {
     private Long id;
 
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
-    private List<Pet> pets;
+    private List<Pet> pets = new ArrayList<>();
 
     @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
-    private List<Diary> diaries;
+    private List<Diary> diaries = new ArrayList<>();
 
     private String username;
     private String password;

--- a/src/main/java/com/dasibom/practice/domain/User.java
+++ b/src/main/java/com/dasibom/practice/domain/User.java
@@ -7,13 +7,14 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
 @Entity
 public class User {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "userId")
     private Long id;
 

--- a/src/main/java/com/dasibom/practice/domain/dto/DiarySaveReqDto.java
+++ b/src/main/java/com/dasibom/practice/domain/dto/DiarySaveReqDto.java
@@ -1,0 +1,30 @@
+package com.dasibom.practice.domain.dto;
+
+import com.dasibom.practice.domain.Pet;
+import com.dasibom.practice.domain.Stamp;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiarySaveReqDto {
+
+    @NotNull(message = "대상 동물은 필수 선택 값입니다.")
+    private Pet pet;
+
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수 입력 값입니다.")
+    private String content;
+
+    private List<Stamp> stamps = new ArrayList<>();
+}

--- a/src/main/java/com/dasibom/practice/repository/DiaryImageRepository.java
+++ b/src/main/java/com/dasibom/practice/repository/DiaryImageRepository.java
@@ -1,0 +1,8 @@
+package com.dasibom.practice.repository;
+
+import com.dasibom.practice.domain.DiaryImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryImageRepository extends JpaRepository<DiaryImage, Long> {
+
+}

--- a/src/main/java/com/dasibom/practice/repository/DiaryRepository.java
+++ b/src/main/java/com/dasibom/practice/repository/DiaryRepository.java
@@ -1,0 +1,8 @@
+package com.dasibom.practice.repository;
+
+import com.dasibom.practice.domain.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+}

--- a/src/main/java/com/dasibom/practice/repository/PetRepository.java
+++ b/src/main/java/com/dasibom/practice/repository/PetRepository.java
@@ -1,0 +1,9 @@
+package com.dasibom.practice.repository;
+
+import com.dasibom.practice.domain.Pet;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetRepository extends JpaRepository<Pet, Long> {
+    Optional<Pet> findByPetName(String petName);
+}

--- a/src/main/java/com/dasibom/practice/repository/StampRepository.java
+++ b/src/main/java/com/dasibom/practice/repository/StampRepository.java
@@ -1,0 +1,10 @@
+package com.dasibom.practice.repository;
+
+import com.dasibom.practice.domain.Stamp;
+import com.dasibom.practice.domain.StampType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StampRepository extends JpaRepository<Stamp, Long> {
+    Optional<Stamp> findByStampType(StampType stampType);
+}

--- a/src/main/java/com/dasibom/practice/repository/UserRepository.java
+++ b/src/main/java/com/dasibom/practice/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.dasibom.practice.repository;
+
+import com.dasibom.practice.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository  extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/dasibom/practice/service/DiaryService.java
+++ b/src/main/java/com/dasibom/practice/service/DiaryService.java
@@ -1,0 +1,10 @@
+package com.dasibom.practice.service;
+
+import com.dasibom.practice.domain.Diary;
+import com.dasibom.practice.domain.dto.DiarySaveReqDto;
+
+public interface DiaryService {
+
+    Diary save(DiarySaveReqDto requestDto);
+
+}

--- a/src/main/java/com/dasibom/practice/service/DiaryServiceImpl.java
+++ b/src/main/java/com/dasibom/practice/service/DiaryServiceImpl.java
@@ -1,0 +1,82 @@
+package com.dasibom.practice.service;
+
+import com.dasibom.practice.domain.Diary;
+import com.dasibom.practice.domain.DiaryStamp;
+import com.dasibom.practice.domain.Pet;
+import com.dasibom.practice.domain.Stamp;
+import com.dasibom.practice.domain.User;
+import com.dasibom.practice.domain.dto.DiarySaveReqDto;
+import com.dasibom.practice.repository.DiaryRepository;
+import com.dasibom.practice.repository.PetRepository;
+import com.dasibom.practice.repository.StampRepository;
+import com.dasibom.practice.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiaryServiceImpl implements DiaryService {
+
+    private final UserRepository userRepository;
+    private final PetRepository petRepository;
+    private final DiaryRepository diaryRepository;
+    private final StampRepository stampRepository;
+
+    @Override
+    @Transactional
+    public Diary save(DiarySaveReqDto requestDto) {
+
+        // TODO: 하드 코딩 변경
+        Optional<User> user = userRepository.findByUsername("test");
+
+        if (user.isPresent()) {
+            int stampListSize = 3;
+//        if (stamps.size() > stampListSize) {
+//            TODO: exception handling
+//        }
+
+            List<Stamp> stamps = getStamps(requestDto);
+            List<DiaryStamp> diaryStamps = getDiaryStamps(stamps);
+            Optional<Pet> pet = petRepository.findByPetName(requestDto.getPet().getPetName());
+            if (pet.isPresent()) {
+                return getDiary(requestDto, user.get(), diaryStamps, pet.get());
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private Diary getDiary(DiarySaveReqDto requestDto, User user, List<DiaryStamp> diaryStamps, Pet pet) {
+        Diary diary = Diary.createDiary(user, pet, requestDto.getTitle(), requestDto.getContent(), diaryStamps);
+        diaryRepository.save(diary);
+        return diary;
+    }
+
+    private List<DiaryStamp> getDiaryStamps(List<Stamp> stamps) {
+        List<DiaryStamp> diaryStamps = new ArrayList<>();
+        for (Stamp stamp : stamps) {
+            DiaryStamp diarystamp = DiaryStamp.createDiaryStamp(stamp);
+            diaryStamps.add(diarystamp);
+        }
+        return diaryStamps;
+    }
+
+    private List<Stamp> getStamps(DiarySaveReqDto requestDto) {
+        List<Stamp> stamps = new ArrayList<>();
+        for (Stamp stamp : requestDto.getStamps()) {
+            // TODO: exception handling
+            Optional<Stamp> byStampType = stampRepository.findByStampType(stamp.getStampType());
+            if (byStampType.isPresent()) {
+                stamps.add(byStampType.get());
+            }
+        }
+        return stamps;
+    }
+
+}

--- a/src/main/java/com/dasibom/practice/service/S3Service.java
+++ b/src/main/java/com/dasibom/practice/service/S3Service.java
@@ -1,0 +1,11 @@
+package com.dasibom.practice.service;
+
+import com.dasibom.practice.domain.Diary;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Service {
+
+    List<String> uploadImage(List<MultipartFile> multipartFile, String dirName, Diary diary);
+
+}

--- a/src/main/java/com/dasibom/practice/service/S3ServiceImpl.java
+++ b/src/main/java/com/dasibom/practice/service/S3ServiceImpl.java
@@ -1,0 +1,104 @@
+package com.dasibom.practice.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.dasibom.practice.domain.Diary;
+import com.dasibom.practice.domain.DiaryImage;
+import com.dasibom.practice.repository.DiaryImageRepository;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3Service {
+
+    private final AmazonS3Client amazonS3Client;
+    private final DiaryImageRepository diaryImageRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    public String bucket;
+
+    // 게시글 이미지 업로드
+    @Override
+    public List<String> uploadImage(List<MultipartFile> multipartFile, String dirName, Diary diary) {
+
+        List<String> fileNameList = new ArrayList<>();
+        List<String> imageUrl = new ArrayList<>();
+
+        uploadS3(multipartFile, dirName, fileNameList, imageUrl);
+
+        try {
+            storeInfoInDb(imageUrl, fileNameList, diary);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return fileNameList;
+    }
+
+    // S3 업로드 로직
+    private void uploadS3(List<MultipartFile> multipartFile, String dirName, List<String> fileNameList,
+            List<String> imageUrl) {
+
+        multipartFile.forEach(file -> {
+            String fileName = createFileName(file.getOriginalFilename(), dirName);
+
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(file.getSize());
+            objectMetadata.setContentType(file.getContentType());
+
+            // s3에 업로드
+            try (InputStream inputStream = file.getInputStream()) {
+                amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                        .withCannedAcl(CannedAccessControlList.PublicRead));
+            } catch (IOException e) {
+                // TODO: exception handling
+                log.error(e.getMessage());
+            }
+
+            fileNameList.add(fileName);
+            imageUrl.add(amazonS3Client.getUrl(bucket, fileName).toString());
+        });
+    }
+
+    // db에 url 과 fileName 정보 저장
+    public void storeInfoInDb(List<String> imageUrls, List<String> fileNameList, Diary diary) throws IOException {
+        for (int i = 0; i < imageUrls.size(); i++) {
+            DiaryImage img = new DiaryImage();
+            img.setImgUrl(imageUrls.get(i));
+            img.setFileName(fileNameList.get(i));
+            img.setDiary(diary);
+
+            diaryImageRepository.save(img);
+        }
+    }
+
+    // 유니크한 파일의 이름을 생성하는 로직
+    private String createFileName(String originalName, String dirName) {
+        return dirName + "/" + UUID.randomUUID() + getFileExtension(originalName);
+    }
+
+    // 파일의 확장자 명을 가져오는 로직 (file 형식 확인)
+    private String getFileExtension(String fileName) {
+        String fileExtension = fileName.substring(fileName.lastIndexOf("."));
+        if (fileExtension.equals(".jpeg") || fileExtension.equals(".jpg") || fileExtension.equals(".png")) {
+            return fileExtension;
+        } else {
+            // TODO: exception handling
+            log.error("error!!!");
+            return null;
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,14 +8,19 @@ spring:
         globally_quoted_identifiers: true
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
-  cache:
-    type: redis
-  redis:
-    host: redis
-    port: 6379
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+  # ==== S3 파일 업로드 용량 설정 ==== #
+  servlet:
+    multipart:
+      max-file-size: 3MB # 업로드 파일 크기 제한
+      max-request-size: 5MB # 업로드 파일 크기 총량 제한
+  # ==== 외부 설정파일 주입 ==== #
+  config:
+    import:
+      - aws-s3.yml
+
 logging.level:
   org.hibernate.SQL: debug
 


### PR DESCRIPTION
### 🧐 Motivation
- 일기 작성 api를 추가했습니다

<br>

### 🎯 Key Changes
- AWS S3 관련 config 설정
- 엔티티 repository 추가
- text 저장과 파일 업로드를 동시에 할 수 있는 controller 추가
- 일기 생성과 파일 업로드 상세 로직은 service 코드에 작성

<br>

### 💬 To Reviewers
- ERD를 설계할 때 이미지 엔티티를 깜박해서 `DiaryImage`라는 이름으로 추가했습니다! `Diary`와 `DiaryImage`의 관계는 일대다로 설정했습니다 :)
- 예외 처리는 아직 하지 않았으니 감안해주세요!
- S3 버킷을 연동하기 위해서 환경변수가 담긴 `aws-s3.yml` 파일이 필요한데요! 민감한 정보이다보니 gitignore에 등록해서 git에는 올라기지 않았으니 따로 전달드리겠습니다!
- PR 단위는 작게 가져갈수록 좋은데 이미지 업로드와 일기 작성 로직 모두를 처리하다보니 파일 변동이 많아진 것 같아요ㅜㅜ 이후부터는 작게 가져가도록 하겠습니다! 궁금한점 있으시면 편하게 코멘트 남겨주세요!!
