### PR TITLE
Feature/15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.8'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10" // QueryDSL
 }
 
 group = 'com.dasibom'
@@ -33,8 +34,35 @@ dependencies {
 	// Swagger
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0'
+	implementation "com.querydsl:querydsl-apt:5.0.0"
+	implementation "com.querydsl:querydsl-core:5.0.0"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+// === QueryDSL 추가 시작===
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
+}
+// === QueryDSL 추가 끝===

--- a/src/main/java/com/dasibom/practice/condition/DiaryReadCondition.java
+++ b/src/main/java/com/dasibom/practice/condition/DiaryReadCondition.java
@@ -1,0 +1,19 @@
+package com.dasibom.practice.condition;
+
+import lombok.Data;
+
+@Data
+public class DiaryReadCondition {
+
+    private String searchKeyword; // 검색 키워드
+
+    // 전체 일기 조회
+    public DiaryReadCondition() {
+    }
+
+    // 전체 일기 검색
+    public DiaryReadCondition(String searchKeyword) {
+        this.searchKeyword = searchKeyword;
+    }
+
+}

--- a/src/main/java/com/dasibom/practice/config/QuerydslConfig.java
+++ b/src/main/java/com/dasibom/practice/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.dasibom.practice.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/dasibom/practice/controller/DiaryController.java
+++ b/src/main/java/com/dasibom/practice/controller/DiaryController.java
@@ -1,7 +1,10 @@
 package com.dasibom.practice.controller;
 
+import com.dasibom.practice.condition.DiaryReadCondition;
 import com.dasibom.practice.domain.Diary;
+import com.dasibom.practice.domain.Pet;
 import com.dasibom.practice.domain.Response;
+import com.dasibom.practice.dto.DiaryBriefInfoDto;
 import com.dasibom.practice.dto.DiaryDetailResDto;
 import com.dasibom.practice.dto.DiarySaveReqDto;
 import com.dasibom.practice.service.DiaryService;
@@ -10,7 +13,11 @@ import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,6 +50,15 @@ public class DiaryController {
     @GetMapping("/detail/{diaryId}")
     public DiaryDetailResDto getDetailedDiary(@PathVariable("diaryId") long diaryId) {
         return diaryService.getDetailedDiary(diaryId);
+    }
+
+    @GetMapping("/list")
+    public Slice<DiaryBriefInfoDto> list(Long cursor, String searchKeyword, Pet pet,
+            @PageableDefault(size = 5, sort = "createAt") Pageable pageRequest) {
+        if (StringUtils.hasText(searchKeyword)) {
+            return diaryService.getDiaryList(cursor, new DiaryReadCondition(searchKeyword), pageRequest); // searchKeyword 가 포함된 일기 조회
+        }
+        return diaryService.getDiaryList(cursor, new DiaryReadCondition(), pageRequest); // 모든 일기 조회
     }
 
 }

--- a/src/main/java/com/dasibom/practice/domain/User.java
+++ b/src/main/java/com/dasibom/practice/domain/User.java
@@ -10,8 +10,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class User {
 
     @Id

--- a/src/main/java/com/dasibom/practice/dto/DiaryBriefInfoDto.java
+++ b/src/main/java/com/dasibom/practice/dto/DiaryBriefInfoDto.java
@@ -1,0 +1,32 @@
+package com.dasibom.practice.dto;
+
+import com.dasibom.practice.domain.Diary;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryBriefInfoDto {
+
+    private Long diaryId;
+    private String petName;
+    private String title;
+    private String content;
+    private String author;
+    private String createdAt;
+
+    public DiaryBriefInfoDto(Diary diary) {
+        this.diaryId = diary.getId();
+        this.petName = diary.getPet().getPetName();
+        this.title = diary.getTitle();
+        this.content = diary.getContent();
+        this.author = diary.getAuthor().getUsername();
+        this.createdAt = diary.getCreatedAt().toString();
+    }
+}

--- a/src/main/java/com/dasibom/practice/repository/DiaryRepository.java
+++ b/src/main/java/com/dasibom/practice/repository/DiaryRepository.java
@@ -1,8 +1,9 @@
 package com.dasibom.practice.repository;
 
 import com.dasibom.practice.domain.Diary;
+import com.dasibom.practice.repository.custom.CustomDiaryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DiaryRepository extends JpaRepository<Diary, Long> {
+public interface DiaryRepository extends JpaRepository<Diary, Long>, CustomDiaryRepository {
 
 }

--- a/src/main/java/com/dasibom/practice/repository/custom/CustomDiaryRepository.java
+++ b/src/main/java/com/dasibom/practice/repository/custom/CustomDiaryRepository.java
@@ -1,0 +1,12 @@
+package com.dasibom.practice.repository.custom;
+
+import com.dasibom.practice.condition.DiaryReadCondition;
+import com.dasibom.practice.dto.DiaryBriefInfoDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface CustomDiaryRepository {
+
+    Slice<DiaryBriefInfoDto> getDiaryBriefInfoScroll(Long cursorId, DiaryReadCondition condition, Pageable pageable);
+
+}

--- a/src/main/java/com/dasibom/practice/repository/custom/CustomDiaryRepositoryImpl.java
+++ b/src/main/java/com/dasibom/practice/repository/custom/CustomDiaryRepositoryImpl.java
@@ -1,0 +1,93 @@
+package com.dasibom.practice.repository.custom;
+
+import static com.dasibom.practice.domain.QDiary.diary;
+
+import com.dasibom.practice.condition.DiaryReadCondition;
+import com.dasibom.practice.domain.Diary;
+import com.dasibom.practice.domain.Pet;
+import com.dasibom.practice.dto.DiaryBriefInfoDto;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomDiaryRepositoryImpl implements CustomDiaryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 게시글 조회 및 검색
+    @Override
+    public Slice<DiaryBriefInfoDto> getDiaryBriefInfoScroll(Long cursorId, DiaryReadCondition condition,
+        Pageable pageable) {
+
+        List<Diary> diaryList = queryFactory
+            .select(diary)
+            .from(diary)
+            .where(
+                eqTitle(condition.getSearchKeyword()),
+                eqContent(condition.getSearchKeyword()),
+                eqCursorId(cursorId)
+            )
+            .limit(pageable.getPageSize() + 1) // limit 보다 데이터를 1개 더 들고와서, 해당 데이터가 있다면 hasNext 변수에 true 를 넣어 알림
+            .orderBy(sortDiaryList(pageable)) // 최신순 정렬
+            .fetch();
+
+        List<DiaryBriefInfoDto> briefDiaryInfos = new ArrayList<>();
+        for (Diary diary : diaryList) {
+            briefDiaryInfos.add(new DiaryBriefInfoDto(diary));
+        }
+
+        boolean hasNext = false;
+        if (briefDiaryInfos.size() > pageable.getPageSize()) {
+            briefDiaryInfos.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        return new SliceImpl<>(briefDiaryInfos, pageable, hasNext);
+    }
+
+    // 특정 기준 정렬
+    private OrderSpecifier<?> sortDiaryList(Pageable page) {
+        // 서비스에서 보내준 Pageable 객체에 정렬조건 null 값 체크
+        if (page.getSort().isEmpty()) {
+            return new OrderSpecifier<>(Order.DESC, diary.createdAt);
+        } else {
+            // 정렬값이 들어 있으면 for 사용하여 값을 가져오기
+            for (Sort.Order order : page.getSort()) {
+                // 서비스에서 넣어준 DESC or ASC 를 가져오기
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                // 서비스에서 넣어준 정렬 조건을 스위치 케이스 문을 활용하여 세팅
+                switch (order.getProperty()) {
+                    case "updatedTime":
+                        return new OrderSpecifier<>(direction, diary.createdAt);
+                }
+            }
+        }
+        return new OrderSpecifier<>(Order.DESC, diary.createdAt);
+    }
+
+    //동적 쿼리를 위한 BooleanExpression
+    private BooleanExpression eqCursorId(Long cursorId) {
+        return (cursorId == null) ? null : diary.id.gt(cursorId);
+    }
+
+    // 제목에 keyword 포함되어있는지 필터링
+    private BooleanExpression eqTitle(String keyword) {
+        return (keyword == null) ? null : diary.title.contains(keyword);
+    }
+
+    // 내용에 keyword 포함되어있는지 필터링
+    private BooleanExpression eqContent(String keyword) {
+        return (keyword == null) ? null : diary.content.contains(keyword);
+    }
+
+}

--- a/src/main/java/com/dasibom/practice/service/DiaryService.java
+++ b/src/main/java/com/dasibom/practice/service/DiaryService.java
@@ -1,13 +1,19 @@
 package com.dasibom.practice.service;
 
+import com.dasibom.practice.condition.DiaryReadCondition;
 import com.dasibom.practice.domain.Diary;
+import com.dasibom.practice.dto.DiaryBriefInfoDto;
 import com.dasibom.practice.dto.DiaryDetailResDto;
 import com.dasibom.practice.dto.DiarySaveReqDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface DiaryService {
 
     Diary save(DiarySaveReqDto requestDto);
 
     DiaryDetailResDto getDetailedDiary(Long diaryId);
+
+    Slice<DiaryBriefInfoDto> getDiaryList(Long cursor, DiaryReadCondition condition, Pageable pageRequest);
 
 }

--- a/src/main/java/com/dasibom/practice/service/DiaryServiceImpl.java
+++ b/src/main/java/com/dasibom/practice/service/DiaryServiceImpl.java
@@ -6,11 +6,13 @@ import static com.dasibom.practice.exception.ErrorCode.STAMP_LIST_SIZE_ERROR;
 import static com.dasibom.practice.exception.ErrorCode.STAMP_NOT_FOUND;
 import static com.dasibom.practice.exception.ErrorCode.USER_NOT_FOUND;
 
+import com.dasibom.practice.condition.DiaryReadCondition;
 import com.dasibom.practice.domain.Diary;
 import com.dasibom.practice.domain.DiaryStamp;
 import com.dasibom.practice.domain.Pet;
 import com.dasibom.practice.domain.Stamp;
 import com.dasibom.practice.domain.User;
+import com.dasibom.practice.dto.DiaryBriefInfoDto;
 import com.dasibom.practice.dto.DiaryDetailResDto;
 import com.dasibom.practice.dto.DiarySaveReqDto;
 import com.dasibom.practice.exception.CustomException;
@@ -23,6 +25,8 @@ import java.util.List;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -61,6 +65,12 @@ public class DiaryServiceImpl implements DiaryService {
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
         return new DiaryDetailResDto(diary);
+    }
+
+    @Override
+    @Transactional
+    public Slice<DiaryBriefInfoDto> getDiaryList(Long cursor, DiaryReadCondition condition, Pageable pageRequest) {
+        return diaryRepository.getDiaryBriefInfoScroll(cursor, condition, pageRequest);
     }
 
     private Diary getDiary(DiarySaveReqDto requestDto, User user, List<DiaryStamp> diaryStamps, Pet pet) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+  # ==== 페이징 할 때 기본값, 20개씩 조회 ==== #
+  data:
+    web:
+      pageable:
+        default-page-size: 5
   # ==== S3 파일 업로드 용량 설정 ==== #
   servlet:
     multipart:


### PR DESCRIPTION
### 🧐 Motivation
- 일기 목록을 확인하기 위해 구현했습니다.

<br>

### 🎯 Key Changes
- 일기 리스트 조회 api
- 무한 스크롤 적용

<br>

### 💬 To Reviewers
- Page 대신 Slice 를 사용했습니다! [이 글](https://velog.io/@dltkdgns3435/SpringBoot-Spring-Data-JPA-%EC%97%90%EC%84%9C-Page%EC%99%80-Slice)참고하시면 도움이 될 것 같아요!
- 실행하시기 전에 터미널에서 `./gradlew clean compileQuerydsl`로 Q-type 객체를 먼저 생성해주어야 합니다! (Q-type 객체는 git에 올라가지 않기 때문입니다)
