### PR TITLE
#20 feat: 일기 등록과 파일 업로드 api 분리

### DIFF
--- a/src/main/java/com/dasibom/practice/exception/ErrorCode.java
+++ b/src/main/java/com/dasibom/practice/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     METHOD_ARG_NOT_VALID(HttpStatus.BAD_REQUEST, "제약 조건을 위배한 요청입니다 (method argument not valid)"),
     STAMP_LIST_SIZE_ERROR(HttpStatus.BAD_REQUEST, "최대 3개의 스탬프를 선택할 수 있습니다"),
     INVALID_FILE_ERROR(HttpStatus.BAD_REQUEST, "확장자가 jpg, jpeg, png 인 파일만 업로드 가능합니다."),
+    FILE_NOT_EXIST_ERROR(HttpStatus.BAD_REQUEST, "파일이 존재하지 않습니다."),
 
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다"),

--- a/src/main/java/com/dasibom/practice/service/S3Service.java
+++ b/src/main/java/com/dasibom/practice/service/S3Service.java
@@ -8,4 +8,6 @@ public interface S3Service {
 
     List<String> uploadImage(List<MultipartFile> multipartFile, String dirName, Diary diary);
 
+    List<String> uploadImage_onlyFile(List<MultipartFile> multipartFile, String dirName);
+
 }

--- a/src/main/java/com/dasibom/practice/service/S3ServiceImpl.java
+++ b/src/main/java/com/dasibom/practice/service/S3ServiceImpl.java
@@ -51,6 +51,23 @@ public class S3ServiceImpl implements S3Service {
         return fileNameList;
     }
 
+    @Override
+    public List<String> uploadImage_onlyFile(List<MultipartFile> multipartFile, String dirName) {
+
+        List<String> fileNameList = new ArrayList<>();
+        List<String> imageUrl = new ArrayList<>();
+
+        uploadS3(multipartFile, dirName, fileNameList, imageUrl);
+
+        try {
+            storeInfoInDb_onlyFile(imageUrl, fileNameList);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return fileNameList;
+    }
+
     // S3 업로드 로직
     private void uploadS3(List<MultipartFile> multipartFile, String dirName, List<String> fileNameList,
             List<String> imageUrl) {
@@ -82,6 +99,16 @@ public class S3ServiceImpl implements S3Service {
             img.setImgUrl(imageUrls.get(i));
             img.setFileName(fileNameList.get(i));
             img.setDiary(diary);
+
+            diaryImageRepository.save(img);
+        }
+    }
+
+    public void storeInfoInDb_onlyFile(List<String> imageUrls, List<String> fileNameList) throws IOException {
+        for (int i = 0; i < imageUrls.size(); i++) {
+            DiaryImage img = new DiaryImage();
+            img.setImgUrl(imageUrls.get(i));
+            img.setFileName(fileNameList.get(i));
 
             diaryImageRepository.save(img);
         }


### PR DESCRIPTION
### 🧐 Motivation
- 기존 일기작성 api는 이미지를 포함한 게시글 업로드 방식으로 진행하였으나, client 연동 과정에서 이미지 업로드와 게시글 업로드를 따로 분리해보자는 제안을 해주셔서 따로 분리하였습니다.

<br>

### 🎯 Key Changes
- 일기 작성 api 구현
- 파일 업로드 api 구현

<br>

### 💬 To Reviewers
- 리뷰어에게 전달할 말을 작성해 주세요
